### PR TITLE
Annotate the hand-written Additions, add Disable*Callback helpers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,10 @@ jobs:
           # notes written for 8.1.2 rather than silently falling back to raw commit subjects.
           notes="docs/release-notes/${VERSION}.md"
           [ -f "${notes}" ] || notes="docs/release-notes/${VERSION%%-*}.md"
-          # Last resort, the native line itself: lets 8.1.2.2 reuse notes filed as 8.1.2.md.
+          # Last resort, the native line itself: lets a maintainer file line-generic notes as
+          # 8.1.2.md once and have every 8.1.2.x revision reuse them. Revision-specific files
+          # (8.1.2.1.md) are deliberately not reused by later revisions - a new revision without
+          # its own notes falls back to the generated commit list instead.
           [ -f "${notes}" ] || notes="docs/release-notes/$(printf '%s' "${VERSION%%-*}" | cut -d. -f1-3).md"
 
           {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
       are not comparable - do not read one as newer than the other.
     -->
     <FFmpegKitNativeVersion>8.1.2</FFmpegKitNativeVersion>
-    <FFmpegKitBindingRevision>1</FFmpegKitBindingRevision>
+    <FFmpegKitBindingRevision>2</FFmpegKitBindingRevision>
     <VersionPrefix>$(FFmpegKitNativeVersion).$(FFmpegKitBindingRevision)</VersionPrefix>
 
     <!-- Which FFmpegKit variant to build. CI builds each of these in turn. -->

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ dotnet pack src/FFmpegKit.iOS/FFmpegKit.iOS.csproj \
 
 ### Regenerating the binding
 
-Only needed when bumping to a newer native FFmpegKit version. The binding is generated with [Objective Sharpie](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/maui/) from the vendored frameworks' public headers:
+Only needed when bumping to a newer native FFmpegKit version. The binding is generated with [Objective Sharpie](https://learn.microsoft.com/en-us/previous-versions/xamarin/cross-platform/macios/binding/objective-sharpie/) from the vendored frameworks' public headers:
 
 ```sh
 # Stage the public headers from the device slice

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![NuGet](https://img.shields.io/nuget/v/FFmpegKit.Net.Video.iOS?label=nuget)](https://www.nuget.org/packages/FFmpegKit.Net.Video.iOS)
 [![release](https://github.com/sbokatuk/FFmpegKit.iOS/actions/workflows/release.yml/badge.svg)](https://github.com/sbokatuk/FFmpegKit.iOS/actions/workflows/release.yml)
-[![Targets: net8.0 | net9.0 | net10.0](https://img.shields.io/badge/targets-net8.0%20%7C%20net9.0%20%7C%20net10.0-512BD4)](#packages)
+[![Targets: net8.0 | net9.0 | net10.0](https://img.shields.io/badge/targets-net8.0%20%7C%20net9.0%20%7C%20net10.0-512BD4)](#installation)
 [![ffmpeg 8.1.2](https://img.shields.io/badge/ffmpeg-8.1.2-632CA6)](#about)
-[![Licence: MIT AND LGPL-3.0 or GPL-3.0](https://img.shields.io/badge/licence-MIT%20AND%20LGPL--3.0%20or%20GPL--3.0-orange)](#licence)
+[![Licence: MIT AND LGPL-3.0 or GPL-3.0](https://img.shields.io/badge/licence-MIT%20AND%20LGPL--3.0%20or%20GPL--3.0-orange)](#license)
 
 .NET for iOS and .NET MAUI bindings for the native **FFmpegKit** library.
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ var probe = await FFprobeKit.GetMediaInformationAsync(path);
 Console.WriteLine(probe.MediaInformation?.Format);
 ```
 
+Global log and statistics hooks take lambdas, and are cleared by name:
+
+```c#
+FFmpegKitConfig.EnableLogCallback(log => Console.WriteLine(log.Message));
+FFmpegKitConfig.DisableLogCallback();          // likewise DisableStatisticsCallback()
+```
+
+Both callbacks arrive on an FFmpegKit worker thread — marshal before touching UI — and are
+held by FFmpegKit until cleared, so anything they capture stays alive too.
+
 More examples and usage can be found in the [original FFmpegKit wiki](https://github.com/arthenica/ffmpeg-kit/wiki/iOS). That repository is archived, but the Objective-C API it documents is the one these bindings expose, so it remains the reference.
 
 ## Building

--- a/build/FetchXcFrameworks.sh
+++ b/build/FetchXcFrameworks.sh
@@ -136,7 +136,7 @@ for variant in $VARIANTS; do
     # Fetch the manifest first: a variant that does not exist for this version fails here, before
     # 200 MB has been downloaded.
     checksums="$WORK_DIR/$variant-checksums.json"
-    if ! curl -fsSL -o "$checksums" "$base/checksums.json"; then
+    if ! curl -fsSL --retry 3 --retry-delay 2 -o "$checksums" "$base/checksums.json"; then
         echo "error: no checksums.json for $FFMPEG_KIT_VERSION-$tag - does that release exist?" >&2
         exit 1
     fi
@@ -146,7 +146,7 @@ for variant in $VARIANTS; do
 
     for framework in $FRAMEWORKS; do
         archive="$WORK_DIR/$variant-$framework.zip"
-        curl -fsSL -o "$archive" "$base/$framework.xcframework.zip"
+        curl -fsSL --retry 3 --retry-delay 2 -o "$archive" "$base/$framework.xcframework.zip"
 
         expected=$(sed -n "s/.*\"$framework\"[[:space:]]*:[[:space:]]*\"\([0-9a-f]*\)\".*/\1/p" "$checksums" | head -1)
         if [ -z "$expected" ]; then

--- a/docs/release-notes/8.1.2.2.md
+++ b/docs/release-notes/8.1.2.2.md
@@ -1,0 +1,6 @@
+## What's changed
+
+Binding revision 2 of FFmpeg `8.1.2`. The native xcframeworks are unchanged; this is binding-surface work only.
+
+- The hand-written additions — the async wrappers and the ergonomics helpers in `Ffmpegkit.Ios` — now carry **nullable reference annotations** (`#nullable enable` per file). The generated binding surface remains unannotated.
+- **`FFmpegKitConfig.DisableLogCallback()`** and **`DisableStatisticsCallback()`** are the new way to clear the global callbacks. The native parameters were always nullable (`[NullAllowed]`), but the binding surface could not say so, leaving nullable-enabled consumers to write `EnableLogCallback(null!)`. The device tests and the sample now use the named methods.

--- a/samples/FFmpegKit.iOS.Example/FFmpegKitExample.csproj
+++ b/samples/FFmpegKit.iOS.Example/FFmpegKitExample.csproj
@@ -81,14 +81,17 @@
 	<!--
 	  Resolved from ./artifacts through the local feed in the repository's NuGet.config, not from
 	  nuget.org, so the sample always exercises your local build. Run BuildNugets.sh first. The
-	  version defaults to FFmpegKitNativeVersion; pass -p:FFmpegKitVersion=8.1.2-rc.1 to point it
-	  at a specific build.
+	  version defaults to VersionPrefix - the full four-part version including the binding
+	  revision. Defaulting to the three-part FFmpegKitNativeVersion instead would let NuGet's
+	  lowest-match resolution prefer an older published revision (8.1.2.1) over the local pack
+	  (8.1.2.2), silently building the sample against a stale binding. Pass
+	  -p:FFmpegKitVersion=8.1.2-rc.1 to point it at a specific build.
 
 	  It references the Full (LGPL) variant deliberately - swapping to a -gpl one would make the
 	  sample itself GPL-3.0.
 	-->
 	<PropertyGroup>
-		<FFmpegKitVersion Condition=" '$(FFmpegKitVersion)' == '' ">$(FFmpegKitNativeVersion)</FFmpegKitVersion>
+		<FFmpegKitVersion Condition=" '$(FFmpegKitVersion)' == '' ">$(VersionPrefix)</FFmpegKitVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/FFmpegKit.iOS.Example/MainPage.xaml.cs
+++ b/samples/FFmpegKit.iOS.Example/MainPage.xaml.cs
@@ -102,7 +102,10 @@ public partial class MainPage : ContentPage
 				null => "no return code",
 				{ IsValueSuccess: true } => $"success, {session.Duration} ms, {session.State}",
 				{ IsValueCancel: true } => "cancelled",
-				_ => $"failed (code {returnCode.Value}): {session.FailStackTrace}",
+				// A command that ran and failed explains itself in Output (its last line is
+				// FFmpeg's error message); FailStackTrace only exists when the session could
+				// not run at all.
+				_ => $"failed (code {returnCode.Value}): {LastLine(session.Output) ?? session.FailStackTrace}",
 			};
 
 			if (returnCode is { IsValueSuccess: true })
@@ -127,6 +130,11 @@ public partial class MainPage : ContentPage
 		_cancellation?.Cancel();
 		StatusLabel.Text = "Cancelling…";
 	}
+
+	static string? LastLine(string? output) =>
+		output?.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) is { Length: > 0 } lines
+			? lines[^1]
+			: null;
 
 	void SetBusy(bool isBusy, string status)
 	{

--- a/samples/FFmpegKit.iOS.Example/MainPage.xaml.cs
+++ b/samples/FFmpegKit.iOS.Example/MainPage.xaml.cs
@@ -112,9 +112,9 @@ public partial class MainPage : ContentPage
 		}
 		finally
 		{
-			// Passing null clears the callback; leaving it registered would keep updating the
-			// progress bar during the next operation.
-			FFmpegKitConfig.EnableStatisticsCallback(null!);
+			// Leaving the callback registered would keep updating the progress bar during the
+			// next operation.
+			FFmpegKitConfig.DisableStatisticsCallback();
 			_cancellation.Dispose();
 			_cancellation = null;
 		}

--- a/src/FFmpegKit.iOS/Additions/Ergonomics.cs
+++ b/src/FFmpegKit.iOS/Additions/Ergonomics.cs
@@ -1,9 +1,26 @@
 using System;
 
+// The generated binding compiles with Nullable disabled and carries no annotations; these
+// hand-written additions are annotation-correct, so nullable-enabled consumers get real
+// nullability information for at least the surface they touch most.
+#nullable enable
+
 namespace Ffmpegkit.Ios
 {
 	public partial class FFmpegKitConfig
 	{
+		/// <summary>Stops routing FFmpeg log lines to a previously enabled callback.</summary>
+		/// <remarks>
+		/// Equivalent to passing null to <see cref="EnableLogCallback"/>. The generated binding
+		/// ships no nullable annotations, so nullable-enabled callers would otherwise need the
+		/// null-forgiving <c>EnableLogCallback (null!)</c> to express this.
+		/// </remarks>
+		public static void DisableLogCallback () => EnableLogCallback (null!);
+
+		/// <summary>Stops routing FFmpeg statistics samples to a previously enabled callback.</summary>
+		/// <remarks>Equivalent to passing null to <see cref="EnableStatisticsCallback"/>.</remarks>
+		public static void DisableStatisticsCallback () => EnableStatisticsCallback (null!);
+
 		/// <summary>The current log level, as the <see cref="Ffmpegkit.Ios.Level"/> enum.</summary>
 		/// <remarks>
 		/// The bound <see cref="LogLevel"/> is an <see cref="int"/>, faithfully to the native

--- a/src/FFmpegKit.iOS/Additions/FFmpegKit.Async.cs
+++ b/src/FFmpegKit.iOS/Additions/FFmpegKit.Async.cs
@@ -2,6 +2,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Ffmpegkit.Ios
 {
 	public partial class FFmpegKit

--- a/src/FFmpegKit.iOS/Additions/FFprobeKit.Async.cs
+++ b/src/FFmpegKit.iOS/Additions/FFprobeKit.Async.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Ffmpegkit.Ios
 {
 	public partial class FFprobeKit

--- a/tests/FFmpegKit.iOS.DeviceTests/SmokeTests.cs
+++ b/tests/FFmpegKit.iOS.DeviceTests/SmokeTests.cs
@@ -250,9 +250,7 @@ public static class SmokeTests
         }
         finally
         {
-            // Clearing the callback is what the native API expects a null here to mean; the
-            // binding just does not model the parameter as nullable.
-            FFmpegKitConfig.EnableLogCallback(null!);
+            FFmpegKitConfig.DisableLogCallback();
         }
 
         Assert(Volatile.Read(ref lines) > 0, "The log delegate never fired.");
@@ -290,7 +288,7 @@ public static class SmokeTests
         }
         finally
         {
-            FFmpegKitConfig.EnableStatisticsCallback(null!);
+            FFmpegKitConfig.DisableStatisticsCallback();
         }
 
         Assert(Volatile.Read(ref updates) > 0, "The statistics delegate never fired.");


### PR DESCRIPTION
The binding compiles with Nullable disabled because the generated surface has no annotations, which also stripped them from the hand-written Additions - the async wrappers and ergonomics consumers touch most. Those files now opt in with #nullable enable.

Clearing the global callbacks previously required the null-forgiving EnableLogCallback(null!) even though the native parameter is [NullAllowed]; DisableLogCallback()/DisableStatisticsCallback() say it by name. The device tests and the sample now use them.