### PR TITLE
CI: build the sample on the net8 and net10 extremes as a matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,11 +129,33 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  sample:
-    name: build sample app
-    timeout-minutes: 20
+  build-samples:
+    name: sample build (${{ matrix.tfm }})
+    # Release iOS AOT is slow here: the trimmer and LLVM (MtouchUseLlvm defaults on) statically
+    # link ~150 MB of FFmpeg per target framework - measured at 7m43s locally against 19s for the
+    # old Debug check, and a runner is slower still, so an earlier attempt was killed at 48
+    # minutes. The two legs run concurrently, so wall-clock is one leg, not two; the ceiling is
+    # generous to stay clear of that historical kill.
+    timeout-minutes: 90
     needs: pack
     runs-on: macos-15
+    strategy:
+      # fail-fast off: the net8 and net10 legs fail for opposite reasons - an old UI dependency
+      # dropping the oldest band, or a new one not yet supporting the newest - so a red net10 next
+      # to a green net8 already localises the cause.
+      fail-fast: false
+      matrix:
+        # The net8 and net10 extremes of what the binding ships, each on its own SDK band. The
+        # sample restores the packed package through a PackageReference exactly as a consumer
+        # would and links under the Release AOT toolchain, where a binding that restores fine in
+        # Debug can still fail to link. It regressed silently once - regenerating the binding
+        # turned session.ReturnCode()/State() into properties and nothing built the sample to
+        # notice.
+        include:
+          - band: net8
+            tfm: net8.0-ios18.0
+          - band: net10
+            tfm: net10.0-ios26.0
     steps:
       - uses: actions/checkout@v4
 
@@ -143,10 +165,24 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
-      - name: Install MAUI workload
-        run: dotnet workload install maui-ios
+      - name: Install the MAUI iOS workload for the ${{ matrix.band }} band
+        run: |
+          # The sample targets exactly one framework per band (SampleSdkBand), so a single band's
+          # workload is enough and restore never walks a framework this band cannot build. Pinned
+          # through a scratch global.json because .NET for iOS couples the target framework to the
+          # SDK band that carries the matching workload.
+          major="$(printf '%s' '${{ matrix.band }}' | sed 's/net//')"
+          sdk="$(dotnet --list-sdks | grep "^${major}\." | tail -1 | cut -d' ' -f1)"
+          dir="${RUNNER_TEMP}/workload-${{ matrix.band }}"
+          mkdir -p "${dir}"
+          ( cd "${dir}" \
+            && dotnet new globaljson --sdk-version "${sdk}" --force \
+            && dotnet workload install maui-ios )
 
       - name: Download packages
         uses: actions/download-artifact@v4
@@ -154,25 +190,22 @@ jobs:
           name: nuget-packages
           path: artifacts
 
-      # The sample consumes the packed package exactly as a user would, so it is the only thing
-      # that checks the API is still usable the way the README documents. It regressed silently
-      # once already: regenerating the binding turned session.ReturnCode() and session.State()
-      # into properties, and nothing built the sample to notice.
-      #
-      # Debug, and pinned to the simulator, because this is a compile check and nothing here is
-      # shipped. Release on a MAUI app pulls in the trimmer and LLVM (MtouchUseLlvm defaults to
-      # true) and then statically links ~150 MB of FFmpeg per target framework: measured locally
-      # at 7m43s against 19s for this command, and a runner is far slower still - the first
-      # attempt at this job was killed after 48 minutes.
-      #
-      # Both target frameworks the .NET 9 band covers are built, since at this cost it is free.
-      # The sample deliberately does not target net10; the device tests cover that.
-      - name: Build the sample against the packed package
+      - name: Build the ${{ matrix.tfm }} sample against the packed package
         run: |
-          dotnet build samples/FFmpegKit.iOS.Example/FFmpegKitExample.csproj \
-            --configuration Debug \
-            -p:RuntimeIdentifier=iossimulator-arm64 \
-            -p:FFmpegKitVersion="${{ inputs.version }}"
+          # Built on the band's own SDK: the repository global.json pins .NET 9, so a scratch
+          # global.json in the invocation directory selects the band that owns this framework.
+          # Release, so the AOT/trimmer path is exercised; pinned to the simulator RID because the
+          # sample is built and never launched, so Release's device-signing concerns do not apply.
+          major="$(printf '%s' '${{ matrix.band }}' | sed 's/net//')"
+          sdk="$(dotnet --list-sdks | grep "^${major}\." | tail -1 | cut -d' ' -f1)"
+          dir="${RUNNER_TEMP}/build-${{ matrix.band }}"
+          mkdir -p "${dir}"
+          printf '{ "sdk": { "version": "%s", "rollForward": "latestFeature" } }\n' "${sdk}" > "${dir}/global.json"
+          ( cd "${dir}" && dotnet build "${GITHUB_WORKSPACE}/samples/FFmpegKit.iOS.Example/FFmpegKitExample.csproj" \
+              --configuration Release -f "${{ matrix.tfm }}" \
+              -p:RuntimeIdentifier=iossimulator-arm64 \
+              -p:SampleSdkBand="${{ matrix.band }}" \
+              -p:FFmpegKitVersion="${{ inputs.version }}" )
 
   e2e:
     name: simulator smoke test (${{ matrix.target-framework }})

--- a/samples/FFmpegKit.iOS.Example/FFmpegKitExample.csproj
+++ b/samples/FFmpegKit.iOS.Example/FFmpegKitExample.csproj
@@ -2,17 +2,20 @@
 
 	<PropertyGroup>
 		<!--
-		  Both target frameworks the .NET 9 SDK band can build, so the sample proves the package
-		  resolves on each. net10.0-ios26.0 is deliberately left out: it needs the .NET 10 band,
-		  which would mean a second SDK and MAUI workload install to compile a sample that
-		  exercises exactly the same API. The device tests already run against net10.
+		  One target framework per SDK band, selected by SampleSdkBand, so the CI sample matrix can
+		  build the net8 and net10 extremes each on its own band (a single SDK + workload per leg,
+		  and restore never walks a framework that band cannot build). Unset locally it is the net9
+		  dev band, so `dotnet build` just works without a second SDK install.
 
-		  The platform version is pinned to match the package's lib/ folders. Bare net9.0-ios
-		  resolves to the iOS 26 reference pack, which refuses to build unless Xcode is exactly
-		  26.0 - an unnecessary constraint for a sample. A consuming app targeting a later
-		  platform version still resolves these assets, since 18.0 is compatible with them.
+		  The platform version is pinned per band to match the package's lib/ folders. Bare
+		  net9.0-ios resolves to the iOS 26 reference pack, which refuses to build unless Xcode is
+		  exactly 26.0; net10.0-ios26.0 legitimately wants that pack. A consuming app targeting a
+		  later platform version still resolves these assets, since 18.0 is compatible with them.
 		-->
-		<TargetFrameworks>net8.0-ios18.0;net9.0-ios18.0</TargetFrameworks>
+		<SampleSdkBand Condition=" '$(SampleSdkBand)' == '' ">net9</SampleSdkBand>
+		<TargetFrameworks Condition=" '$(SampleSdkBand)' == 'net8' ">net8.0-ios18.0</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(SampleSdkBand)' == 'net9' ">net9.0-ios18.0</TargetFrameworks>
+		<TargetFrameworks Condition=" '$(SampleSdkBand)' == 'net10' ">net10.0-ios26.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 
@@ -72,10 +75,22 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="4.1.2" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+	</ItemGroup>
+
+	<!--
+	  CommunityToolkit.Maui.MediaElement (the before/after video preview) has no single version
+	  that spans net8 and net10, so it is selected per band along with a matching
+	  Microsoft.Extensions.Logging.Debug. 4.1.2 covers net8 and net9; net10 needs 10.0.0.
+	-->
+	<ItemGroup Condition="!$(TargetFramework.StartsWith('net10.0'))">
+		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="4.1.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
+		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
 	</ItemGroup>
 
 	<!--

--- a/samples/FFmpegKit.iOS.Example/FFmpegKitExample.csproj
+++ b/samples/FFmpegKit.iOS.Example/FFmpegKitExample.csproj
@@ -74,9 +74,19 @@
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<!--
+	  $(MauiVersion) is whatever Controls the installed workload bundles, which on the net10 band
+	  is older than the 10.0.60 CommunityToolkit.Maui.MediaElement 10.0.0 declares - restore then
+	  fails NU1605. Controls is an ordinary NuGet package independent of the workload pack, so the
+	  net10 band pins the toolkit's floor explicitly; net8 and net9 keep the workload's own.
+	-->
+	<ItemGroup Condition="!$(TargetFramework.StartsWith('net10.0'))">
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.60" />
 	</ItemGroup>
 
 	<!--

--- a/samples/FFmpegKit.iOS.Example/MauiProgram.cs
+++ b/samples/FFmpegKit.iOS.Example/MauiProgram.cs
@@ -10,7 +10,13 @@ public static class MauiProgram
 		var builder = MauiApp.CreateBuilder();
 		builder
 			.UseMauiApp<App>()
+#if NET10_0_OR_GREATER
+			// MediaElement 10.0.0 made the Android foreground-service opt-in a required argument.
+			// This sample previews a local file while in the foreground, and it is iOS-only anyway.
+			.UseMauiCommunityToolkitMediaElement(isAndroidForegroundServiceEnabled: false)
+#else
 			.UseMauiCommunityToolkitMediaElement()
+#endif
 			.ConfigureFonts(fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");


### PR DESCRIPTION
The sample built net8+net9 in Debug and deliberately skipped net10, so the newest asset set went unbuilt and Release AOT/trimmer link issues went unseen. It now selects one framework per SDK band via SampleSdkBand (net9 by default, so local `dotnet build` still works), and a build-samples matrix builds the net8 and net10 extremes in Release, each on its own band through a scratch global.json, fail-fast off, pinned to the simulator RID.

Release iOS AOT is slow - the trimmer and LLVM statically link ~150 MB of FFmpeg per framework - so the two legs run concurrently under a generous timeout, well clear of the 48-minute kill an earlier single-job attempt hit.

CommunityToolkit.Maui.MediaElement (the video preview) has no version spanning net8 and net10, so it and Microsoft.Extensions.Logging.Debug are now selected per band: 4.1.2/8.0.1 for net8 and net9, 10.0.0/10.0.0 for net10. Verified: the net9 band builds clean; the net10 versions are confirmed on nuget.org with the net10.0-ios26.0 assets, and their Release build runs in the matrix.