### PR TITLE
Fix real-device crash: default Registrar to dynamic on iOS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
       are not comparable - do not read one as newer than the other.
     -->
     <FFmpegKitNativeVersion>8.1.2</FFmpegKitNativeVersion>
-    <FFmpegKitBindingRevision>2</FFmpegKitBindingRevision>
+    <FFmpegKitBindingRevision>3</FFmpegKitBindingRevision>
     <VersionPrefix>$(FFmpegKitNativeVersion).$(FFmpegKitBindingRevision)</VersionPrefix>
 
     <!-- Which FFmpegKit variant to build. CI builds each of these in turn. -->

--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ held by FFmpegKit until cleared, so anything they capture stays alive too.
 
 More examples and usage can be found in the [original FFmpegKit wiki](https://github.com/arthenica/ffmpeg-kit/wiki/iOS). That repository is archived, but the Objective-C API it documents is the one these bindings expose, so it remains the reference.
 
+## Troubleshooting
+
+**Crash on a real device: `Could not find the type 'ObjCRuntime.__Registrar__'`.** From `8.1.2.3` the package handles this for you — you should not see it. It happens because .NET 9 made the *managed static* registrar the device default, and that registrar does not emit the per-assembly `__Registrar__` lookup type for this binding, so the first call returning a bound Objective-C object (for example `FFprobeKit.GetMediaInformationAsync`, which returns a `MediaInformationSession`) crashes at load. It is the .NET SDK issue [dotnet/macios#22071](https://github.com/dotnet/macios/issues/22071), not a fault in the binding, and the simulator never hits it because the simulator/interpreter path uses a different registrar — which is why it can pass every simulator test and still crash on a phone.
+
+The package ships a `buildTransitive` target that defaults consuming apps (including apps that reference it only through `FFmpegKit.Net.Full.Maui`) to **`Registrar=dynamic`**, which resolves classes by reflection and sidesteps the gap. To override it, set `<Registrar>` yourself in the app project:
+
+- **NativeAOT** (`PublishAot=true`) requires the managed static registrar, so a NativeAOT app must set `Registrar` explicitly; this particular crash remains until the upstream issue is fixed.
+- **`Registrar=static`** (the classic static registrar) also avoids the crash and is lighter at runtime than `dynamic`; it is a reasonable override once verified on a device.
+
+`partial-static`, which the [macOS binding](https://github.com/sbokatuk/FFmpegKit.Mac) defaults to for the equivalent failure, is not usable on iOS — it produces duplicate-symbol link errors against `Microsoft.iOS.registrar.a`.
+
 ## Building
 
 ### Prerequisites

--- a/build/buildTransitive/Registrar.targets
+++ b/build/buildTransitive/Registrar.targets
@@ -1,0 +1,22 @@
+<Project>
+  <!--
+    The managed static registrar (the default Registrar on a real iOS device -
+    Xamarin.Shared.Sdk.targets' SelectRegistrar target - since the simulator/interpreter path
+    never hits this) requires the linker to inject a per-assembly ObjCRuntime.__Registrar__ type
+    into every assembly that defines bound NSObject subclasses. That injection never happens for
+    this binding assembly, regardless of TrimMode/TrimmerRootAssembly/IsTrimmable on the consuming
+    app's side - the app then crashes with "Could not find the type 'ObjCRuntime.__Registrar__'
+    in the assembly '<this assembly>'" the moment a binding call returns a bound type (e.g.
+    FFprobeKit.GetMediaInformationAsync's MediaInformationSession).
+
+    Registrar=dynamic sidesteps the whole per-assembly lookup table by resolving Objective-C
+    classes through runtime reflection instead, which is unaffected by this gap. Defaulting to it
+    here - unless the app already set Registrar explicitly - mirrors how the Mac binding defaults
+    Registrar to partial-static via its own buildTransitive target (see this repository's README
+    Troubleshooting section for that equivalent failure); partial-static itself isn't an option
+    here since it produces duplicate-symbol link errors against Microsoft.iOS.registrar.a on iOS.
+  -->
+  <PropertyGroup Condition="'$(Registrar)' == '' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+    <Registrar>dynamic</Registrar>
+  </PropertyGroup>
+</Project>

--- a/build/buildTransitive/Registrar.targets
+++ b/build/buildTransitive/Registrar.targets
@@ -9,12 +9,25 @@
     in the assembly '<this assembly>'" the moment a binding call returns a bound type (e.g.
     FFprobeKit.GetMediaInformationAsync's MediaInformationSession).
 
+    This is the .NET SDK issue dotnet/macios#22071, surfaced by .NET 9 promoting the managed
+    static registrar to the device default (it was the classic static registrar in .NET 8); when
+    that issue is fixed upstream this whole target can be removed.
+
     Registrar=dynamic sidesteps the whole per-assembly lookup table by resolving Objective-C
     classes through runtime reflection instead, which is unaffected by this gap. Defaulting to it
     here - unless the app already set Registrar explicitly - mirrors how the Mac binding defaults
     Registrar to partial-static via its own buildTransitive target (see this repository's README
     Troubleshooting section for that equivalent failure); partial-static itself isn't an option
     here since it produces duplicate-symbol link errors against Microsoft.iOS.registrar.a on iOS.
+
+    Two caveats a consumer may need to override for (hence the '$(Registrar)' == '' guard, which
+    always yields to an explicit setting):
+      - NativeAOT (PublishAot=true) requires the managed static registrar, so an app publishing
+        with NativeAOT must set Registrar itself and accept that this crash is unfixed there until
+        the upstream issue is.
+      - The classic static registrar (Registrar=static) does not use __Registrar__ and so also
+        avoids the crash, with a lighter runtime cost than dynamic; it is a reasonable explicit
+        override for an app that has verified it on-device.
   -->
   <PropertyGroup Condition="'$(Registrar)' == '' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
     <Registrar>dynamic</Registrar>

--- a/docs/release-notes/8.1.2.3.md
+++ b/docs/release-notes/8.1.2.3.md
@@ -1,0 +1,22 @@
+## What's changed
+
+Binding revision 3 of FFmpeg `8.1.2`. The native xcframeworks are unchanged; this release fixes a real-device crash.
+
+### Fixed: `Could not find the type 'ObjCRuntime.__Registrar__'` on real devices
+
+On a physical iOS device, the first call returning a bound Objective-C object — for example `FFprobeKit.GetMediaInformationAsync`, which returns a `MediaInformationSession` — crashed at load with:
+
+```
+Could not find the type 'ObjCRuntime.__Registrar__' in the assembly 'FFmpegKit.Net.<Variant>.iOS'
+```
+
+.NET 9 promoted the **managed static registrar** to the device default (it was the classic static registrar in .NET 8), and that registrar does not emit the per-assembly `__Registrar__` lookup type for this binding assembly — regardless of the consuming app's `TrimMode`, `TrimmerRootAssembly` or `IsTrimmable`. It is the .NET SDK issue [dotnet/macios#22071](https://github.com/dotnet/macios/issues/22071), not a fault in the binding. The **simulator never reproduced it** — the simulator/interpreter path uses a different registrar — so it passed every simulator smoke test and still crashed on a phone.
+
+The package now ships a `buildTransitive` target that defaults consuming apps to **`Registrar=dynamic`**, which resolves classes by reflection and sidesteps the gap. It applies transitively, so apps that reference this binding only through `FFmpegKit.Net.Full.Maui` are covered too. The target yields to an explicit `<Registrar>` in the app project.
+
+**If you set `Registrar` yourself**, two things to know, both documented in the README's new Troubleshooting section:
+
+- **NativeAOT** (`PublishAot=true`) requires the managed static registrar, so a NativeAOT app must choose its own `Registrar`; this crash is unfixed there until the upstream issue is.
+- **`Registrar=static`** (the classic static registrar) also avoids the crash and is lighter at runtime than `dynamic` — a reasonable override once verified on a device.
+
+Verified end to end on a real device (iPhone 14 Pro) from clean artifact and NuGet-cache state, both directly and through `FFmpegKit.Net.Full.Maui`, with no explicit `Registrar` override on either.

--- a/src/FFmpegKit.iOS/FFmpegKit.iOS.csproj
+++ b/src/FFmpegKit.iOS/FFmpegKit.iOS.csproj
@@ -161,6 +161,19 @@
     -->
     <None Include="../../LICENSE" Pack="true" PackagePath="licenses/" Visible="false" />
     <None Include="$(FFmpegKitNativeLicenseFile)" Pack="true" PackagePath="licenses/" Visible="false" />
+
+    <!--
+      Defaults consuming apps to Registrar=dynamic on iOS - see the comment in the targets file
+      itself for why. NuGet's buildTransitive convention requires the file be named after the
+      package id so it gets auto-imported (also into projects that reference this only
+      transitively, e.g. through FFmpegKit.Net.Full.Maui), hence the copy-with-rename instead of
+      packing build/buildTransitive/Registrar.targets directly under its own name.
+    -->
+    <None Include="$(IntermediateOutputPath)buildTransitive/$(PackageId).targets" Pack="true" PackagePath="buildTransitive/" Visible="false" />
   </ItemGroup>
+
+  <Target Name="_StageRegistrarBuildTransitiveTarget" BeforeTargets="_GetPackageFiles">
+    <Copy SourceFiles="../../build/buildTransitive/Registrar.targets" DestinationFiles="$(IntermediateOutputPath)buildTransitive/$(PackageId).targets" SkipUnchangedFiles="true" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
On a real iOS device the managed static registrar (the mandatory Registrar mode outside the simulator/interpreter path) never generates an ObjCRuntime.__Registrar__ type for this binding assembly, regardless of the consuming app's TrimMode, TrimmerRootAssembly, or IsTrimmable settings. Any call returning a bound NSObject subclass - e.g. FFprobeKit.GetMediaInformationAsync's MediaInformationSession - then crashes on load with "Could not find the type 'ObjCRuntime.__Registrar__' in the assembly 'FFmpegKit.Net.<Variant>.iOS'".

Registrar=dynamic resolves Objective-C classes through runtime reflection instead of a per-assembly lookup table, sidestepping the gap entirely. Defaulting to it via a buildTransitive target - unless the consuming app already set Registrar explicitly - mirrors how the Mac binding defaults to partial-static; partial-static itself isn't viable here since it produces duplicate-symbol link errors against Microsoft.iOS.registrar.a on iOS.

Verified end to end on a real device (iPhone 14 Pro) from a clean artifact and NuGet cache state, both directly (FFmpegKit.iOS.Example) and through FFmpegKit.Net.Full.Maui's consumer (FFMpegKit.Net's own MAUI sample), with no explicit Registrar override on either.