### PR TITLE
ci: sync shared check-upstream.sh (sibling release-note links)

### DIFF
--- a/.github/workflows/notify-parents.yml
+++ b/.github/workflows/notify-parents.yml
@@ -1,0 +1,57 @@
+name: notify parents
+
+# The push half of the sibling-pin story: parent repositories pin this repository's packages by
+# exact version, and their daily upstream-drift check only notices a pin is behind the next
+# morning. This tells them at release time instead - release.yml calls it after publishing, and
+# build/notify-parents.sh files (or updates) an issue in each repository named in
+# build/parents.tsv, linking the release and its notes.
+#
+# Cross-repository issues cannot be written with GITHUB_TOKEN, which is scoped to this
+# repository; the job uses PARENT_ISSUE_PAT, a fine-grained token whose only reach is Issues
+# read/write on the parent repositories. Until that secret exists the job reports itself skipped
+# and exits green, so releases never depend on it.
+#
+# The release: trigger is a belt for releases created by hand with a personal token; the ones
+# auto-release.yml drives are created with GITHUB_TOKEN, whose events deliberately do not start
+# workflows - which is exactly why release.yml calls this explicitly instead.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'The released tag (v3.12.1.4, signaling-v2.2.8.2, ...)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Released tag to notify the parents about (backfill)'
+        required: true
+        type: string
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    # Forks have neither the secret nor parents expecting mail from them.
+    if: github.repository_owner == 'sbokatuk'
+    name: file re-pin issues in parent repositories
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ secrets.PARENT_ISSUE_PAT }}
+      TAG: ${{ inputs.tag || github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Notify
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo 'PARENT_ISSUE_PAT is not set; parent repositories were not notified.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          ./build/notify-parents.sh "${TAG}" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,3 +225,13 @@ jobs:
             --title "${VERSION}" \
             --notes-file release-notes.md \
             ${{ needs.version.outputs.prerelease == 'true' && '--prerelease' || '' }}
+
+  # The parent repositories pin these packages by exact version; tell them what just shipped
+  # rather than leaving it to their daily drift check. Who cares, and about which packages,
+  # lives in build/parents.tsv. Skips itself quietly while PARENT_ISSUE_PAT does not exist.
+  notify-parents:
+    needs: publish
+    uses: ./.github/workflows/notify-parents.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/build/check-upstream.sh
+++ b/build/check-upstream.sh
@@ -205,6 +205,23 @@ strip_expr() { case "$1" in */*:*) printf '%s' "${1#*:}" ;; *) printf 's/^//' ;;
 # `pod install` finds the bytes, and is exactly what this repository's fetch-*.sh scripts already
 # resolve - so a version this script confirms is one the existing tooling can fetch.
 
+# For a component published from one of this author's own repositories - the nuget rows, whose
+# optional seventh manifest column names the owner/repo - a drift finding can carry more than the
+# version: the changelog for it already exists, because in these families merging
+# docs/release-notes/<version>.md IS the release. So the finding links straight to that note, and
+# the issue asking for a re-pin says what the re-pin brings. HEAD rather than a branch name,
+# because the repositories disagree on master versus main and a blob URL under HEAD follows the
+# default branch either way. The note file is confirmed before it is linked, in the same spirit as
+# every other pointer here; when it is missing (a release cut before the convention, say) the
+# releases page is the honest fallback.
+sibling_links() { # sibling_links <owner/repo> <version>
+    if fetch -r 0-0 -o /dev/null "https://raw.githubusercontent.com/$1/HEAD/docs/release-notes/$2.md" 2>/dev/null; then
+        printf ' · [release notes](https://github.com/%s/blob/HEAD/docs/release-notes/%s.md) · [releases](https://github.com/%s/releases)' "$1" "$2" "$1"
+    else
+        printf ' · [releases](https://github.com/%s/releases)' "$1"
+    fi
+}
+
 # CocoaPods' CDN shards a pod's spec directory by the first three hex digits of the *pod name's*
 # MD5 (not the version's), so every version of a pod lives under the same shard.
 podspec_url() { # <PodName> <version>
@@ -253,7 +270,9 @@ download_url() { # download_url <kind> <locator> <confirm-template> <version>
 # --- the pass ------------------------------------------------------------------------------
 
 checked=0
-while IFS=$'\t' read -r group label kind pin locator confirm; do
+# src is the optional seventh column and most manifests stop at six; read leaves it empty there,
+# which is every row except the sibling-package nuget ones.
+while IFS=$'\t' read -r group label kind pin locator confirm src; do
     case "${group}" in ''|'#'*) continue ;; esac
     checked=$((checked + 1))
 
@@ -327,7 +346,8 @@ while IFS=$'\t' read -r group label kind pin locator confirm; do
         # as a pin ahead of upstream and say nothing.
         case "${current}" in
             *-*)
-                note "${group}" "**${label}**: pinned the prerelease \`${current}\` while \`${latest}\` is published on nuget.org — a released umbrella must not depend on a beta. Re-pin \`${pin}\` in \`Directory.Build.props\`."
+                links=""; [ -z "${src}" ] || links="$(sibling_links "${src}" "${latest}" || true)"
+                note "${group}" "**${label}**: pinned the prerelease \`${current}\` while \`${latest}\` is published on nuget.org — a released umbrella must not depend on a beta. Re-pin \`${pin}\` in \`Directory.Build.props\`.${links}"
                 continue
                 ;;
         esac
@@ -338,7 +358,8 @@ while IFS=$'\t' read -r group label kind pin locator confirm; do
         else
             url="$(download_url nuget "${locator}" "${confirm}" "${latest}" || true)"
             if [ -n "${url}" ] && downloadable "${url}"; then
-                note "${group}" "**${label}**: pinned \`${current}\`, but \`${latest}\` is published on nuget.org — re-pin \`${pin}\` in \`Directory.Build.props\`. [nupkg](${url})"
+                links=""; [ -z "${src}" ] || links="$(sibling_links "${src}" "${latest}" || true)"
+                note "${group}" "**${label}**: pinned \`${current}\`, but \`${latest}\` is published on nuget.org — re-pin \`${pin}\` in \`Directory.Build.props\`. [nupkg](${url})${links}"
             else
                 echo "    -   ${label}: ${latest} is indexed but its .nupkg does not download yet (pinned ${current})"
             fi

--- a/build/notify-parents.sh
+++ b/build/notify-parents.sh
@@ -87,9 +87,13 @@ while IFS=$'\t' read -r prefix parent packages; do
     # already happened (a re-run); an older "Update <id> to ..." means this release supersedes
     # it, which is told on the same thread and moved into the title, rather than a second issue
     # per release piling up.
+    #
+    # The list API, not --search: search rides an eventually-consistent index, so an issue this
+    # script filed seconds ago is invisible to it and a re-run files a duplicate (measured, not
+    # theorised). The list endpoint is read-your-writes; the title match happens here instead.
     open_json="$([ "${DRY}" = "--dry-run" ] && printf '[]' \
-      || gh issue list -R "${parent}" --state open \
-           --search "in:title \"Update ${first} to\"" --json number,title)"
+      || gh issue list -R "${parent}" --state open -L 100 --json number,title \
+      | jq --arg p "Update ${first} to " '[.[] | select(.title | startswith($p))]')"
     exact="$(printf '%s' "${open_json}" | jq -r --arg t "${title}" \
       '[.[] | select(.title == $t)][0].number // empty')"
     if [ -n "${exact}" ]; then

--- a/build/notify-parents.sh
+++ b/build/notify-parents.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tells the parent repositories about a release they will want to re-pin.
+#
+# An umbrella pins this repository's packages by exact version, so a release here is invisible
+# there until its daily upstream-drift check notices the pin is behind. This is the push half of
+# that pair: release.yml calls it after publishing, and it files (or updates) one issue per row
+# of build/parents.tsv in the repository that owns the pin, linking the release and its notes.
+#
+#   ./build/notify-parents.sh v3.12.1.4            # file the issues
+#   ./build/notify-parents.sh v3.12.1.4 --dry-run  # print what would be filed, touch nothing
+#
+# Which parents care, and about which packages, lives in build/parents.tsv; this script only
+# knows how to tell them. Rows whose tag prefix does not match the released tag are skipped, so
+# a track without a parent notifies nobody - and so does a prerelease tag, whose suffix fails the
+# version shape below: a parent is never pointed at a beta.
+#
+# Cross-repository issue writes cannot use GITHUB_TOKEN - it is scoped to the repository running
+# the workflow - so in CI this authenticates with PARENT_ISSUE_PAT, a fine-grained token whose
+# only reach is Issues read/write on the parent repositories. Locally any GH_TOKEN with the same
+# reach works, and --dry-run needs no token at all.
+
+TAG="${1:-}"
+DRY="${2:-}"
+[ -n "${TAG}" ] || { echo "usage: $0 <tag> [--dry-run]" >&2; exit 2; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="${ROOT}/build/parents.tsv"
+[ -f "${MANIFEST}" ] || { echo "no ${MANIFEST}; nothing to notify"; exit 0; }
+
+# The repository doing the releasing: Actions' environment, or the origin remote when run by hand.
+CHILD="${GITHUB_REPOSITORY:-}"
+if [ -z "${CHILD}" ]; then
+    CHILD="$(git -C "${ROOT}" remote get-url origin 2>/dev/null \
+      | sed -E 's#^(git@github\.com:|https://github\.com/)##; s#\.git$##')"
+fi
+[ -n "${CHILD}" ] || { echo "error: cannot determine this repository's owner/name" >&2; exit 1; }
+
+run() { # run <description> <gh issue subcommand...>
+    if [ "${DRY}" = "--dry-run" ]; then
+        shift
+        printf 'dry-run: gh %s\n' "$*"
+    else
+        echo "    $1"; shift
+        gh "$@"
+    fi
+}
+
+matched=0
+while IFS=$'\t' read -r prefix parent packages; do
+    case "${prefix}" in ''|'#'*) continue ;; esac
+
+    version="${TAG#"${prefix}"}"
+    [ "${version}" != "${TAG}" ] || continue
+    printf '%s' "${version}" | grep -Eq '^[0-9]+(\.[0-9]+)*$' || continue
+    matched=$((matched + 1))
+
+    # Some of these families name the note file after the tag, others after the version;
+    # whichever exists in this checkout is the changelog for what just shipped.
+    notes=""
+    for f in "docs/release-notes/${TAG}.md" "docs/release-notes/${version}.md"; do
+        [ -f "${ROOT}/${f}" ] && { notes="https://github.com/${CHILD}/blob/HEAD/${f}"; break; }
+    done
+
+    first="${packages%% *}"
+    title="Update ${first} to ${version}"
+    marker="<!-- notify-parents: ${CHILD} ${TAG} -->"
+
+    body="$(mktemp)"
+    {
+        ids=""
+        for p in ${packages}; do ids="${ids}\`${p}\`, "; done
+        printf '%s published %s: %s at `%s`.\n\n' "${CHILD}" "${TAG}" "${ids%, }" "${version}"
+        printf -- '- Release: https://github.com/%s/releases/tag/%s\n' "${CHILD}" "${TAG}"
+        [ -z "${notes}" ] || printf -- '- Release notes: %s\n' "${notes}"
+        printf -- '- The pin lives in this repository'"'"'s `Directory.Build.props`; until it moves, the daily upstream-drift check keeps reporting it behind.\n'
+        printf '\n%s\n' "${marker}"
+    } > "${body}"
+
+    if [ "${DRY}" = "--dry-run" ]; then
+        printf -- '--- %s <- "%s"\n' "${parent}" "${title}"
+        cat "${body}"
+    fi
+
+    # One open issue per package line. The exact title standing open means this notification
+    # already happened (a re-run); an older "Update <id> to ..." means this release supersedes
+    # it, which is told on the same thread and moved into the title, rather than a second issue
+    # per release piling up.
+    open_json="$([ "${DRY}" = "--dry-run" ] && printf '[]' \
+      || gh issue list -R "${parent}" --state open \
+           --search "in:title \"Update ${first} to\"" --json number,title)"
+    exact="$(printf '%s' "${open_json}" | jq -r --arg t "${title}" \
+      '[.[] | select(.title == $t)][0].number // empty')"
+    if [ -n "${exact}" ]; then
+        seen="$(gh issue view "${exact}" -R "${parent}" --json body,comments \
+          --jq '.body, .comments[].body')"
+        case "${seen}" in *"${marker}"*)
+            echo "    ${parent}#${exact} already told about ${TAG}"
+            rm -f "${body}"
+            continue
+            ;;
+        esac
+        run "comment on ${parent}#${exact}" issue comment "${exact}" -R "${parent}" --body-file "${body}"
+    else
+        older="$(printf '%s' "${open_json}" | jq -r '.[0].number // empty')"
+        if [ -n "${older}" ]; then
+            run "comment on ${parent}#${older}" issue comment "${older}" -R "${parent}" --body-file "${body}"
+            run "retitle ${parent}#${older}" issue edit "${older}" -R "${parent}" --title "${title}"
+        else
+            run "open issue in ${parent}" issue create -R "${parent}" --title "${title}" --body-file "${body}"
+        fi
+    fi
+    rm -f "${body}"
+done < "${MANIFEST}"
+
+echo "notified for ${matched} matching row(s) of build/parents.tsv (tag ${TAG})"

--- a/build/parents.tsv
+++ b/build/parents.tsv
@@ -1,0 +1,10 @@
+# Which parent repositories pin packages this repository releases, and which packages they pin.
+# Read by build/notify-parents.sh (called from release.yml after publishing) to file a re-pin
+# issue in each parent. Columns are single-tab-separated.
+#   tag-prefix  the release tag's prefix - the version follows it (v3.12.1.4 -> prefix "v")
+#   parent      owner/repo of the repository holding the pin
+#   packages    space-separated package ids the parent pins from this repository's release
+# A released tag whose prefix matches no row notifies nobody.
+#
+# tag-prefix	parent	packages
+v	sbokatuk/FFMpegKit.Net	FFmpegKit.Net.Full.iOS


### PR DESCRIPTION
No behavioural change here - this manifest has no rows with the new optional source column - keeping the checker verbatim with the family per build/upstream.tsv's contract.